### PR TITLE
添加地理消息的时候缺少 locationMessageDict[kXMNMessageConfigurationLocationKey]=…

### DIFF
--- a/XMChatBar/Controllers/XMNChatController.m
+++ b/XMChatBar/Controllers/XMNChatController.m
@@ -113,6 +113,7 @@
     locationMessageDict[kXMNMessageConfigurationGroupKey] = @(self.messageChatType);
     locationMessageDict[kXMNMessageConfigurationNicknameKey] = kSelfName;
     locationMessageDict[kXMNMessageConfigurationAvatarKey] = kSelfThumb;
+    locationMessageDict[kXMNMessageConfigurationLocationKey]=locationText;
     [self addMessage:locationMessageDict];
     
 }

--- a/XMChatBar/Views/XMNChatMessageCell/XMNChatLocationMessageCell.m
+++ b/XMChatBar/Views/XMNChatMessageCell/XMNChatLocationMessageCell.m
@@ -53,7 +53,7 @@
 
 - (void)configureCellWithData:(id)data {
     [super configureCellWithData:data];
-
+    _locationAddressL.text=data[kXMNMessageConfigurationLocationKey];
 }
 
 #pragma mark - Getters


### PR DESCRIPTION
…locationText;

XMNChatLocationMessageCell.m的configureCellWithData方法中缺少对_locationAddressL的赋值
